### PR TITLE
add support for property

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -15,7 +15,7 @@ var method = module.exports = function mockMethod(obj, key, method) {
     key: key,
     original: obj[key]
   });
-  obj[key] = method || function() {};
+  obj[key] = method === undefined ? function() {} : method;
 };
 
 

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -25,7 +25,6 @@ describe('Mock methods', function() {
 
     muk(fs, 'readFile', readFileMock);
     muk(fs, 'mkdir', mkdirMock);
-
     assert.equal(fs.readFile, readFileMock, 'object method is equal to mock');
     assert.equal(fs.mkdir, mkdirMock, 'object method is equal to mock');
   });
@@ -43,5 +42,25 @@ describe('Mock methods', function() {
     muk.restore();
     assert.equal(fs.readFile, readFile, 'original method is restored');
     assert.equal(fs.mkdir, mkdir, 'original method is restored');
+  });
+});
+
+describe('Mock property', function () {
+  var config = {
+    enableCache: true,
+    delay: 10
+  };
+
+  it('Contains original property', function () {
+    assert.equal(config.enableCache, true, 'enableCache is true');
+    assert.equal(config.delay, 10, 'delay is 10');
+  });
+
+  it('Property are new after mocked', function () {
+    muk(config, 'enableCache', false);
+    muk(config, 'delay', 0);
+
+    assert.equal(config.enableCache, false, 'enableCache is false');
+    assert.equal(config.delay, 0, 'delay is 0');
   });
 });


### PR DESCRIPTION
In our scene, we sometimes use `muk` like this:  

``` js
describe('#func', function () {
  afterEach(muk.restore);
  it('response mock data', function () {
    muk(config, 'cache', false);
    //do the test
  });
});
```

We sometimes use `muk` for mock property, so that we can use `muk.restore` to restore all the mocked method and properties.
