### PR TITLE
delete prop in restore when it's not own property of object

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -13,7 +13,8 @@ var method = module.exports = function mockMethod(obj, key, method) {
   mocks.push({
     obj: obj,
     key: key,
-    original: obj[key]
+    original: obj[key],
+    exist: key in obj
   });
   obj[key] = method === undefined ? function() {} : method;
 };
@@ -25,7 +26,11 @@ var method = module.exports = function mockMethod(obj, key, method) {
 method.restore = function restoreMocks() {
   for (var i = mocks.length - 1; i >= 0; i--) {
     var m = mocks[i];
-    m.obj[m.key] = m.original;
+    if (!m.exist) {
+      delete m.obj[m.key];
+    } else {
+      m.obj[m.key] = m.original;
+    }
   }
   mocks = [];
 

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -76,9 +76,17 @@ describe('Mock property', function () {
     muk(config, 'enableCache', false);
     muk(config, 'enableCache', false);
     muk(config, 'delay', 0);
+    muk(config, 'notExistProp', 'value');
+    muk(process.env, 'notExistProp', 0);
     muk.restore();
 
     assert.equal(config.enableCache, true, 'enableCache is true');
     assert.equal(config.delay, 10, 'delay is 10');
+    assert(!hasOwnProperty(config, 'notExistProp'), 'notExistProp is deleted');
+    assert(!hasOwnProperty(process.env, 'notExistProp'), 'notExistProp is deleted');
   });
 });
+
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
+}


### PR DESCRIPTION
I found it can't set undefined to process.env

```
process.env.a = undefined
console.log(process.env.a); // show `undefined` it's string!!!
```
