### PR TITLE
Hotfix the bug caused by #4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
+  - "1"
+  - "2"
+  - "3"
+  - "4"
 notifications:
   email:
     on_success: change

--- a/lib/method.js
+++ b/lib/method.js
@@ -12,14 +12,33 @@ var mocks = [];
  * @param {!Function} method
  */
 var method = module.exports = function mockMethod(obj, key, method) {
+  method = method === undefined ? function() {} : method;
+  var hasOwnProperty = obj.hasOwnProperty(key);
   mocks.push({
     obj: obj,
     key: key,
     descriptor: Object.getOwnPropertyDescriptor(obj, key),
-    exist: key in obj
+    // Make sure the key exists on object not the prototype
+    hasOwnProperty: hasOwnProperty
   });
-  delete obj[key];
-  obj[key] = method === undefined ? function() {} : method;
+
+  // delete the origin key, redefine it below
+  if (hasOwnProperty) {
+    delete obj[key];
+  }
+
+  // Can't not delete the property of process.env before node@4
+  if (obj === process.env) {
+    obj[key] = method;
+    return;
+  }
+
+  Object.defineProperty(obj, key, {
+    writable: true,
+    configurable: true,
+    enumerable: true,
+    value: method
+  });
 };
 
 
@@ -29,9 +48,11 @@ var method = module.exports = function mockMethod(obj, key, method) {
 method.restore = function restoreMocks() {
   for (var i = mocks.length - 1; i >= 0; i--) {
     var m = mocks[i];
-    if (!m.exist) {
+    if (!m.hasOwnProperty) {
+      // delete the mock key, use key on the prototype
       delete m.obj[m.key];
     } else {
+      // redefine the origin key instead of the mock key
       Object.defineProperty(m.obj, m.key, m.descriptor);
     }
   }

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -61,6 +61,18 @@ describe('Mock methods', function() {
     assert.equal(fs.readFile, readFile, 'mock twices, original method should be restored too');
   });
 
+  it('should mock method on prototype', function() {
+    var readFile = fs.readFile;
+    var newFs = Object.create(fs);
+    var readFileMock = function(path, callback) {
+      process.nextTick(callback.bind(null, null, 'hello!'));
+    };
+    muk(newFs, 'readFile', readFileMock);
+    assert.equal(newFs.readFile, readFileMock, 'object method is equal to mock');
+
+    muk.restore();
+    assert.equal(newFs.readFile, readFile, 'object method is equal to origin');
+  });
 });
 
 describe('Mock property', function () {
@@ -99,10 +111,19 @@ describe('Mock property', function () {
   });
 
   it('should mock function when method is null', function() {
-    muk.restore();
     muk(config, 'enableCache');
     assert.equal(typeof config.enableCache, 'function', 'enableCache is function');
     assert.equal(config.enableCache(), undefined, 'enableCache return undefined');
+  });
+
+  it('should mock property on prototype', function() {
+    var newConfig = Object.create(config);
+    muk(newConfig, 'enableCache', false);
+    assert.deepEqual(Object.keys(newConfig), ['enableCache'], 'obj should contain properties');
+    assert.equal(newConfig.enableCache, false, 'enableCache is false');
+
+    muk.restore();
+    assert.equal(newConfig.enableCache, true, 'enableCache is false');
   });
 });
 
@@ -127,7 +148,17 @@ describe('Mock getter', function() {
   it('Should have original getter after muk.restore()', function() {
     muk(obj, 'a', 2);
     muk.restore();
-    assert.equal(obj.a, 1, 'property a of obj is equal to mock');
+    assert.equal(obj.a, 1, 'property a of obj is equal to origin');
+  });
+
+  it('should mock property on prototype', function() {
+    var newObj = Object.create(obj);
+    muk(newObj, 'a', 2);
+    assert.deepEqual(Object.keys(newObj), ['a'], 'obj should contain properties');
+    assert.equal(newObj.a, 2, 'property a of obj is equal to mock');
+
+    muk.restore();
+    assert.equal(newObj.a, 1, 'property a of obj is equal to origin');
   });
 });
 


### PR DESCRIPTION
`Object.getOwnPropertyDescriptor` won't get the descriptor from the
prototype, so if we mock the key on the prototype, it will return
undefined.

Use `Object.defineProperty` instead of assignment, because the key can't
override the getter defined on the prototype. Example below.

```
var obj = {
  get a() {
    return 1;
  }
};
var obj2 = Object.create(obj);
obj2.a = 2;
console.log(obj2.a); // return 1
```