### PR TITLE
fix: can't redefine process.env when node<4

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -28,6 +28,14 @@ var method = module.exports = function mockMethod(obj, key, method) {
     delete obj[key];
   }
 
+  // set a flag that checks if it is mocked
+  var flag = cache.get(obj);
+  if (!flag) {
+    flag = new Set();
+    cache.set(obj, flag);
+  }
+  flag.add(key);
+
   // Can't not delete the property of process.env before node@4
   if (obj === process.env) {
     obj[key] = method;
@@ -41,13 +49,6 @@ var method = module.exports = function mockMethod(obj, key, method) {
     value: method
   });
 
-  // set a flag that checks if it is mocked
-  var flag = cache.get(obj);
-  if (!flag) {
-    flag = new Set();
-    cache.set(obj, flag);
-  }
-  flag.add(key);
 };
 
 /**

--- a/lib/method.js
+++ b/lib/method.js
@@ -60,8 +60,14 @@ method.restore = function restoreMocks() {
       // delete the mock key, use key on the prototype
       delete m.obj[m.key];
     } else {
-      // redefine the origin key instead of the mock key
-      Object.defineProperty(m.obj, m.key, m.descriptor);
+      // can't redefine process.env when node<4
+      // https://github.com/nodejs/node/pull/2999
+      if (m.obj === process.env) {
+        m.obj[m.key] = m.descriptor.value;
+      } else {
+        // redefine the origin key instead of the mock key
+        Object.defineProperty(m.obj, m.key, m.descriptor);
+      }
     }
   }
   mocks = [];

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -229,6 +229,12 @@ describe('Mock check', function() {
     muk(obj, 'e', 2);
     assert.ok(muk.isMocked(obj, 'e'));
   });
+
+  it('should check process.env', function() {
+    muk(process.env, 'HOME', '/mockhome');
+    assert.equal(process.env.HOME, '/mockhome');
+    assert.ok(muk.isMocked(process.env, 'HOME'));
+  });
 });
 
 function hasOwnProperty(obj, prop) {

--- a/test/method-test.js
+++ b/test/method-test.js
@@ -80,6 +80,7 @@ describe('Mock property', function () {
     enableCache: true,
     delay: 10
   };
+  var home = process.env.HOME;
 
   afterEach(muk.restore);
 
@@ -91,21 +92,25 @@ describe('Mock property', function () {
   it('Property are new after mocked', function () {
     muk(config, 'enableCache', false);
     muk(config, 'delay', 0);
+    muk(process.env, 'HOME', '/mockhome');
 
     assert.equal(config.enableCache, false, 'enableCache is false');
     assert.equal(config.delay, 0, 'delay is 0');
+    assert.equal(process.env.HOME, '/mockhome', 'process.env.HOME is /mockhome');
   });
 
   it('Should have original properties after muk.restore()', function () {
     muk(config, 'enableCache', false);
     muk(config, 'enableCache', false);
     muk(config, 'delay', 0);
+    muk(process.env, 'HOME', '/mockhome');
     muk(config, 'notExistProp', 'value');
     muk(process.env, 'notExistProp', 0);
     muk.restore();
 
     assert.equal(config.enableCache, true, 'enableCache is true');
     assert.equal(config.delay, 10, 'delay is 10');
+    assert.equal(process.env.HOME, home, 'process.env.HOME is ' + home);
     assert(!hasOwnProperty(config, 'notExistProp'), 'notExistProp is deleted');
     assert(!hasOwnProperty(process.env, 'notExistProp'), 'notExistProp is deleted');
   });


### PR DESCRIPTION
nodejs/node#2999